### PR TITLE
Fix Design issues and update documentation

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -58,7 +58,7 @@ Click on the target platform for the model to download.
 <br>
 ## Run the Xailient SDK Container
 
-    $ docker run -e SDK_LINK="<LINK>" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient model-inference:1.0.1
+    $ docker run -e SDK_LINK="<LINK>" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 Replace `<LINK>` with the SDK link obtained earlier. Here you are passing the link to the container as an environment variable.
 

--- a/docs/container.md
+++ b/docs/container.md
@@ -58,7 +58,7 @@ Click on the target platform for the model to download.
 <br>
 ## Run the Xailient SDK Container
 
-    $ docker run -e SDK_LINK="<LINK>" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient model-inference:1.0.1
+    $ docker run -e SDK_LINK="<LINK>" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient model-inference:1.0.1
 
 Replace `<LINK>` with the SDK link obtained earlier. Here you are passing the link to the container as an environment variable.
 
@@ -68,11 +68,10 @@ run through the Xailient SDK.
 Replace `<OUTPUT_IMAGES_DIR>` with the __full path__ to a directory where the images and videos with their predicted bounding
 boxes drawn will be placed.
 
-Make sure to include __double quotes around the SDK download link, input/output directories__. The link may contain characters like `&` that can cause problems if not quoted, the directories may include white spaces which can also cause problems if not quoted. 
 
 **Example:**
 
-    $ docker run -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "~/Desktop/input:/input" -v "~/Workspace/output:/output" xailient/model-inference:1.0.1
+    $ docker run -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "~/Desktop/input":/input -v "~/Workspace/output":/output xailient/model-inference:1.0.1
 
 In this example, all predicted images and videos will appear in the `~/Workspace/output` of the host OS.
 
@@ -86,6 +85,8 @@ In this example, all predicted images and videos will appear in the `~/Workspace
     Providing an `SDK_LINK` takes precedence over placing the Xailient SDK file in the "input" directory. Therefore, be aware when swapping in different Xailient SDKs.
 
 
+!!! Note
+      Make sure to include __double quotes around the SDK download link, input/output directories__. The link may contain characters like `&` that can cause problems if not quoted, the directories may include white spaces which can also cause problems if not quoted. 
 
 <br>
 ## Default Behaviour
@@ -111,11 +112,11 @@ To disable this set the environment variable IMAGES to False.
 
 When SDK is downloaded from the console:
 
-    $ docker run -e IMAGES=False -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e IMAGES=False -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 When SDK is copied from the console:
 
-    $ docker run -e IMAGES=False -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e IMAGES=False -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 ### REBUILD (default=True)
 Controls whether videos with predicted bounding boxes are created in the output directory for input videos.
@@ -125,11 +126,11 @@ See the `FPS` and `EVERY` option for even more control over the output video tha
 
 When SDK is downloaded from the console:
 
-    $ docker run -e REBUILD=True -e EVERY=20 -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e REBUILD=True -e EVERY=20 -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 When SDK is copied from the console:
 
-    $ docker run -e REBUILD=True -e EVERY=20 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e REBUILD=True -e EVERY=20 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 ### EVERY (default=1)
 Perform inference on every ith frame of all given videos.
@@ -138,11 +139,11 @@ Perform inference on every ith frame of all given videos.
 
 When SDK is downloaded from the console:
 
-    $ docker run -e EVERY=20 -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e EVERY=20 -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 When SDK is copied from the console:
 
-    $ docker run -e EVERY=20 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e EVERY=20 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 ### FPS (defaults to the original video fps)
 Reconstructed videos will have this many frames per second.
@@ -151,11 +152,11 @@ Reconstructed videos will have this many frames per second.
 
 When SDK is downloaded from the console:
 
-    $ docker run -e FPS=30  -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e FPS=30  -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 When SDK is copied from the console:
 
-    $ docker run -e FPS=30  -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e FPS=30  -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 ### THRESHOLD (default=0.5)
 Play around with different confidence thresholds by passing in the environment variable THRESHOLD when running the Container instance. Accepts floating values from 0 to 1.
@@ -164,11 +165,11 @@ Play around with different confidence thresholds by passing in the environment v
 
 When SDK is downloaded from the console:
 
-    $ docker run -e THRESHOLD=0.8 -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e THRESHOLD=0.8 -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 When SDK is copied from the console:
 
-    $ docker run -e THRESHOLD=0.8 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e THRESHOLD=0.8 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 ### LOG (default=True)
 Controls whether a .csv file with bounding boxes for all predicted images is created in the output directory.
@@ -178,11 +179,11 @@ To disable this set the environment variable LOG to False.
 
 When SDK is downloaded from the console:
 
-    $ docker run -e LOG=False -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e LOG=False -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 When SDK is copied from the console:
 
-    $ docker run -e LOG=False -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+    $ docker run -e LOG=False -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>":/input -v "<OUTPUT_IMAGES_DIR>":/output xailient/model-inference:1.0.1
 
 <br>
 ## Releases

--- a/docs/container.md
+++ b/docs/container.md
@@ -38,23 +38,29 @@ Next you will need to [Build a Xailient SDK](buildSdk.md) and choose the **X86-6
 <br>
 ### Obtaining a Link to a Xailient SDK
 
-Go to the [MANAGE AI MODEL page](https://console.xailient.com/user/listModel) and locate the model for which you have built the SDK.
+Go to the Console and navigate to [MANAGE AI MODEL page](https://console.xailient.com/user/listModel). For the model you want to deploy, select the SDK you have build for your target platform. 
 
-Click on __Download/Copy SDK__ button for that model. 
+!!! note
+    If you have not build an SDK yet, refer to __Build SDK__ section of the documentation.
+
+Click on the <img src="../img/console/AI Models/Copy.png" height=30 width=30> icon left side of the platform to copy the downlooad link.
 
 <p align="center">
-<img src="../img/console/SDKBuildComplete.png" heigth=100>
+  <img src="../img/console/AI Models/PreTrainedModels-SDKBuilt-copy.png">
 </p>
 
-A link will be copied to your clipboard and a download will begin.
+Click on the target platform for the model to download.
+
+<p align="center">
+  <img src="../img/console/AI Models/PreTrainedModels-SDKBuilt-downlaod.png">
+</p>
 
 <br>
 ## Run the Xailient SDK Container
 
-    `$ docker run -e SDK_LINK="<LINK>" -v <INPUT_IMAGES_DIR>:/input -v <OUTPUT_IMAGES_DIR>:/output xailient/model-inference:1.0.1`
+    $ docker run -e SDK_LINK="<LINK>" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient model-inference:1.0.1
 
 Replace `<LINK>` with the SDK link obtained earlier. Here you are passing the link to the container as an environment variable.
-Be sure to include __double quotes around the SDK download link__ since the link may contain characters like `&` that can cause problems if not quoted.
 
 Replace `<INPUT_IMAGES_DIR>` with the __full path__ to the directory that has your images and/or videos that you want to
 run through the Xailient SDK.
@@ -62,18 +68,24 @@ run through the Xailient SDK.
 Replace `<OUTPUT_IMAGES_DIR>` with the __full path__ to a directory where the images and videos with their predicted bounding
 boxes drawn will be placed.
 
-Note: You can also place the downloaded Xailient SDK (a python .whl file) into the `<INPUT_IMAGES_DIR> ` directory of the host OS.
- Then you can start the docker container without specifying the Xailient SDK's URL via `-e SDK_LINK="<LINK>"` e.g.
-
-    `$ docker run -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
-
-Providing an `SDK_LINK` takes precedence over placing the Xailient SDK file in the "input" directory. Therefore, be aware when swapping in different Xailient SDKs.
+Make sure to include __double quotes around the SDK download link, input/output directories__. The link may contain characters like `&` that can cause problems if not quoted, the directories may include white spaces which can also cause problems if not quoted. 
 
 **Example:**
 
-    `$ docker run -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v ~/Desktop/input:/input -v ~/Workspace/output:/output xailient/model-inference:1.0.1`
+    $ docker run -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "~/Desktop/input:/input" -v "~/Workspace/output:/output" xailient/model-inference:1.0.1
 
 In this example, all predicted images and videos will appear in the `~/Workspace/output` of the host OS.
+
+!!! Alternative
+      You can also place the downloaded Xailient SDK (a python .whl file) into the `<INPUT_IMAGES_DIR> ` directory of the host OS.
+    
+    Then you can start the docker container without specifying the Xailient SDK's URL via `-e SDK_LINK="<LINK>"` e.g.
+
+    `$ docker run -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1`
+
+    Providing an `SDK_LINK` takes precedence over placing the Xailient SDK file in the "input" directory. Therefore, be aware when swapping in different Xailient SDKs.
+
+
 
 <br>
 ## Default Behaviour
@@ -96,39 +108,81 @@ Controls whether images with predicted bounding boxes are created in the output 
 To disable this set the environment variable IMAGES to False.
 
 **Example:**
-`$ docker run -e IMAGES=False -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
+
+When SDK is downloaded from the console:
+
+    $ docker run -e IMAGES=False -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+
+When SDK is copied from the console:
+
+    $ docker run -e IMAGES=False -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
 
 ### REBUILD (default=True)
 Controls whether videos with predicted bounding boxes are created in the output directory for input videos.
 See the `FPS` and `EVERY` option for even more control over the output video that gets created.
 
 **Example:**
-`$ docker run -e REBUILD=True -e EVERY=20  -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
+
+When SDK is downloaded from the console:
+
+    $ docker run -e REBUILD=True -e EVERY=20 -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+
+When SDK is copied from the console:
+
+    $ docker run -e REBUILD=True -e EVERY=20 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
 
 ### EVERY (default=1)
 Perform inference on every ith frame of all given videos.
 
 **Example:**
-`$ docker run -e EVERY=20 -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
+
+When SDK is downloaded from the console:
+
+    $ docker run -e EVERY=20 -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+
+When SDK is copied from the console:
+
+    $ docker run -e EVERY=20 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
 
 ### FPS (defaults to the original video fps)
 Reconstructed videos will have this many frames per second.
 
 **Example:**
-`$ docker run -e FPS=30 -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
+
+When SDK is downloaded from the console:
+
+    $ docker run -e FPS=30  -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+
+When SDK is copied from the console:
+
+    $ docker run -e FPS=30  -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
 
 ### THRESHOLD (default=0.5)
 Play around with different confidence thresholds by passing in the environment variable THRESHOLD when running the Container instance. Accepts floating values from 0 to 1.
 
 **Example:**
-`$ docker run -e THRESHOLD='0.8' -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
+
+When SDK is downloaded from the console:
+
+    $ docker run -e THRESHOLD=0.8 -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+
+When SDK is copied from the console:
+
+    $ docker run -e THRESHOLD=0.8 -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
 
 ### LOG (default=True)
 Controls whether a .csv file with bounding boxes for all predicted images is created in the output directory.
 To disable this set the environment variable LOG to False.
 
 **Example:**
-`$ docker run -e LOG=False -v <FULL_PATH>:/input -v <FULL_PATH>:/output xailient/model-inference:1.0.1`
+
+When SDK is downloaded from the console:
+
+    $ docker run -e LOG=False -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
+
+When SDK is copied from the console:
+
+    $ docker run -e LOG=False -e SDK_LINK="https://ReallyLongUrl/AAaDDY2MzE1ODQ0NzQx" -v "<INPUT_IMAGES_DIR>:/input" -v "<OUTPUT_IMAGES_DIR>:/output" xailient/model-inference:1.0.1
 
 <br>
 ## Releases
@@ -140,5 +194,5 @@ Enables users to batch process images and videos using their own custom trained 
 <br>
 ## Common Problems
 1. Check that you have used the fullpath to your input and output directories. The Container will still run if you use relative paths however will not work as intended. I.e. Video/image inferencing will **not** work.
-2. Check that you have used double quotations " " around the SDK_LINK. Since the link may contain characters like `&` that can cause problems if not quoted.
+2. Check that you have used double quotations " " around the SDK_LINK. Since the link may contain characters like `&` that can cause problems if not quoted, the directories may include white spaces which can also cause problems if not quoted. 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,14 +17,14 @@
 </figure>
 <!-- blank line -->
 
-<br>
-<a class="button" href="/en/latest/installation/">Getting Started</a>
-<br>
-<br>
-<br>
-<a class="button" href="/en/latest/sample_code/">Sample Code</a>
-<br>
-<br>
-<br>
-<a class="button" href="https://www.xailient.com/blog">Blogs</a>
+## Implementation Code
+
+The code for training a model and implementing based on your use-case can easily become clumsy. Take a look at how elegant and simple Xailient's implementation code are 
+<a href="/en/latest/sample_code/" style="text-decoration:underline; color:#7e57c2">here</a>.
+
+## Blog
+
+Do visit our Blog 
+<a href="https://www.xailient.com/blog" style="text-decoration:underline; color:#7e57c2">here</a>
+to read our expert's take on AI, IoT and how Xailient efficiently tackles one of the major issues in Computer Vision.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-# Deploy Your AI
+# Native Installation
 
 !!! note
       This version of the documentation is for installation of Xailient SDK using wheel file (.whl). 
@@ -111,8 +111,6 @@ Click on the target platform for the model to download.
   <img src="../img/console/AI Models/PreTrainedModels-SDKBuilt-downlaod.png">
 </p>
 
-!!! note
-    When you click the button &lt;ARM32&gt; or &lt;x86_64&gt;, it downloads the SDK wheel file as well as copies the link to the wheel file in your clipboard.
 
 __Install SDK Wheel__
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,8 +3,8 @@
 }
 
 .md-logo img{
-    height: 25px;
-    width: 100px;
+  height: 25px;
+  width: 100px;
 }
 
 /* Buttons */
@@ -18,7 +18,12 @@
   text-transform: uppercase;
 }
 
-button:hover, button:active {
+.button:hover, .button:active {
   background-color: #593696;
   cursor: pointer;
+}
+
+/* Logo img size */
+.md-header-nav__button.md-logo img,.md-header-nav__button.md-logo svg{
+  width:4.2rem;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Xailient Docs
 nav:
+    - Welcome to Xailient SDK Documentation: index.md
     - Getting Started with Console: console_getting_started.md
     - Datasets: dataset.md
     - Pre-trained AI Models: pre_trained_models.md


### PR DESCRIPTION
1. Increased the Xailient logo size.
2. Added a "Welcome to Xailient SDK Documentation" to the navigation pane.
3. In "Welcome to Xailient SDK Documentation" page:
	3.1 Removed the three buttons - "Getting Started with Console", "Code", "Blog".
	3.2 "Getting Started with Console" is automatically added to the footer since we have added "Welcome to Xailient SDK Documentation" in the navigation pane as a separate page.
	3.3 Added Implementation Code and Blog sections to replace the "Code" and "Blog" buttons.
4. Native Installation page under "Deploy your AI"
	4.1 Changed the heading to "Native Installation" from "Deploy your AI"
	4.2 Removed a note from "Get SDK Wheel Link" section since its no longer applicable
5. Docker Container page under "Deploy your AI"
	5.1 Updated the "Obtaining a Link to a Xailient SDK". Used the same contents from the "Get SDK Wheel Link" section of Native installation page.
	5.2 Added two notes to "Run the Xailient SDK Container" section. One note to provide details regarding the alternative method to install the SDK - downloading SDK. Second note was to include the double quotes for SDK_LINK and directories.
	5.3 Modified "Supported Options" section to include commands for two scenarios: SDK downloaded, SDK link copied.